### PR TITLE
fix(linter:js): don't update entry's src if it does not ends with "in…

### DIFF
--- a/lib/commands/lint/index.js
+++ b/lib/commands/lint/index.js
@@ -7,7 +7,7 @@ const normalizeEntrySrc = (entry) => {
   entry.src = Array.isArray(entry.src) ? entry.src : [entry.src];
 
   if (entry.handler === 'rollup') {
-    entry.src = entry.src.map(src => `${dirname(src)}/**/*.{js,vue}`);
+    entry.src = entry.src.map(src => !src.endsWith('index.js') ? src : `${dirname(src)}/**/*.{js,vue}`);
   }
 
   return entry;


### PR DESCRIPTION
…dex.js"

If we have entry `foo/polyfills.js`, it will handle all files from `foo` folder :(