### PR TITLE
improve(build): lazy-load handlers

### DIFF
--- a/lib/commands/build/handle.js
+++ b/lib/commands/build/handle.js
@@ -23,5 +23,5 @@ module.exports = async (cli, entry, args) => {
     }
   }
 
-  return handlers[entry.handler](cli, entry, args)
+  return handlers[entry.handler]()(cli, entry, args)
 };

--- a/lib/commands/build/handlers/index.js
+++ b/lib/commands/build/handlers/index.js
@@ -1,8 +1,8 @@
 module.exports = {
-  js: require('./js'),
-  css: require('./css'),
-  sass: require('./sass'),
-  file: require('./file'),
-  image: require('./image'),
-  rollup: require('./rollup'),
+  js: () => require('./js'),
+  css: () => require('./css'),
+  sass: () => require('./sass'),
+  file: () => require('./file'),
+  image: () => require('./image'),
+  rollup: () => require('./rollup'),
 };


### PR DESCRIPTION
Pour éviter de charger toutes les dépendances de tous les handlers (par exemple rollup et ses plugins) alors qu'on veut juste build du Sass...

Comme ça on évite d'installer une dépendance vue dans le dépôt Plylouth : :man_shrugging: 

![selection_999 040](https://user-images.githubusercontent.com/2103975/47156819-35b37880-d2e8-11e8-8649-a75b02435830.png)

(et en plus on gagne un peu de perf !!)