### PR TITLE
improve: better lint before build

### DIFF
--- a/lib/commands/build/handle.js
+++ b/lib/commands/build/handle.js
@@ -1,4 +1,5 @@
 const handlers = require('./handlers');
+const { lintEntry } = require('../lint');
 
 module.exports = async (cli, entry, args) => {
   if (!(entry.handler in handlers)) {
@@ -7,7 +8,7 @@ module.exports = async (cli, entry, args) => {
 
   if (args.lint) {
     try {
-      await cli.run('lint', args);
+      await lintEntry(cli, entry, args);
     } catch(err) {
       return cli.logger.error(err.message);
     }

--- a/lib/commands/lint/index.js
+++ b/lib/commands/lint/index.js
@@ -3,16 +3,6 @@ const { chain } = require('lodash');
 const { readAssets } = require('../../utils/assets');
 const linters = require('./linters');
 
-const normalizeEntrySrc = (entry) => {
-  entry.src = Array.isArray(entry.src) ? entry.src : [entry.src];
-
-  if (entry.handler === 'rollup') {
-    entry.src = entry.src.map(src => !src.endsWith('index.js') ? src : `${dirname(src)}/**/*.{js,vue}`);
-  }
-
-  return entry;
-};
-
 module.exports = (cli, args) => {
   return new Promise((resolve, reject) => {
     const files = chain(readAssets(cli, args))
@@ -23,7 +13,7 @@ module.exports = (cli, args) => {
 
     Object.entries(files).forEach(([linter, entries]) => {
       if (!(linter in linters)) {
-        throw new Error(`Linter "${linter} do not exists.`);
+        return;
       }
 
       const filesToLint = chain(entries)
@@ -31,9 +21,37 @@ module.exports = (cli, args) => {
         .flatten()
         .value();
 
-      return linters[linter](cli, args, filesToLint)
+      if (filesToLint.length === 0) {
+        return;
+      }
+
+      return linters[linter]()(cli, args, filesToLint)
         .then(() => resolve())
         .catch(err => reject(err));
     });
   });
 };
+
+module.exports.lintEntry = async (cli, entry, args) => {
+  const linter = entry.handler;
+  const normalizedEntry = normalizeEntrySrc(entry);
+
+  if (!(linter in linters)) {
+    return;
+  }
+
+  return linters[linter]()(cli, args, normalizedEntry.src);
+};
+
+function normalizeEntrySrc(entry) {
+  entry = {...entry};
+  entry.src = Array.isArray(entry.src) ? entry.src : [entry.src];
+
+  if (entry.handler === 'rollup') {
+    entry.src = entry.src.map(src => !src.endsWith('index.js') ? src : `${dirname(src)}/**/*.{js,vue}`);
+  }
+
+  entry.src = entry.src.filter(src => !/node_modules/.test(src));
+
+  return entry;
+}

--- a/lib/commands/lint/linters/index.js
+++ b/lib/commands/lint/linters/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  js: require('./js'),
-  rollup: require('./js'),
-  sass: require('./sass'),
+  js: () => require('./js'),
+  rollup: () => require('./js'),
+  sass: () => require('./sass'),
 };


### PR DESCRIPTION
Voir https://github.com/Yproximite/yProx-cli/pull/34#issuecomment-431015965

Bah ça a clairement une meilleure tronche x)

**avant :**
![selection_999 043](https://user-images.githubusercontent.com/2103975/47161065-88456280-d2f1-11e8-9ff1-218ca27b8a55.png)

**après :**
![selection_999 042](https://user-images.githubusercontent.com/2103975/47161069-8a0f2600-d2f1-11e8-91da-67436ac37d50.png)


Aussi j'en profite pour ne pas linter les fichiers dans les `node_modules`, aucun intérêt.