### PR TITLE
fix(linters): don't hardcode available linters

### DIFF
--- a/lib/commands/lint/index.js
+++ b/lib/commands/lint/index.js
@@ -6,7 +6,7 @@ const linters = require('./linters');
 module.exports = (cli, args) => {
   return new Promise((resolve, reject) => {
     const files = chain(readAssets(cli, args))
-      .filter(({ handler }) => ['rollup', 'sass'].includes(handler))
+      .filter(({ handler }) => Object.keys(linters).includes(handler))
       .map(normalizeEntrySrc)
       .groupBy('handler')
       .value();


### PR DESCRIPTION
Because entries with handler `js` were not linted during `yprox-cli lint` :(