### PR TITLE
Refactor configuration structure for "tools"

### DIFF
--- a/lib/commands/build/handlers/rollup.js
+++ b/lib/commands/build/handlers/rollup.js
@@ -23,7 +23,7 @@ module.exports = (api, entry, args) => {
     if (rollupOptions.json) plugins.push(json(rollupOptions.json));
     plugins.push(globals());
     if (rollupOptions.vue) plugins.push(vue(rollupOptions.vue));
-    if (rollupOptions.buble) plugins.push(buble(rollupOptions.buble));
+    if (api.projectOptions.buble) plugins.push(buble(api.projectOptions.buble));
 
     plugins.push(replace({
       ...Object.entries(api.getSafeEnvVars()).reduce((acc, [key, value]) => {

--- a/lib/commands/build/handlers/sass.js
+++ b/lib/commands/build/handlers/sass.js
@@ -11,7 +11,7 @@ const tildeImporter = require('node-sass-tilde-importer');
 module.exports = (api, entry, args) => {
   const sassOptions = Object.assign({
     importer: tildeImporter,
-  }, api.projectOptions.sass);
+  }, api.projectOptions.handlers.sass);
 
   const postcssPlugins = [
     autoprefixer(api.projectOptions.autoprefixer),

--- a/lib/options.js
+++ b/lib/options.js
@@ -3,42 +3,24 @@ const joi = require('joi');
 const schema = joi.object().keys({
   assets: joi.object(),
   path: joi.object(),
-  buble: joi.alternatives(joi.object(), joi.boolean()),
   handlers: joi.object({
-    autoprefixer: joi.object({
-      browsers: joi.array().items(joi.string()),
-    }),
-    cssnano: joi.object({
-      safe: joi.boolean(),
-      autoprefixer: joi.boolean(),
-    }),
-    terser: joi.object({
-      compress: joi.object({
-        drop_console: joi.boolean(),
-      }),
-    }),
-    gifsicle: joi.object({
-      interlaced: joi.boolean(),
-    }),
-    jpegtran: joi.object({
-      progressive: joi.boolean(),
-    }),
-    optipng: joi.object({
-      optimizationLevel: joi.number(),
-    }),
-    svgo: joi.object({
-      plugins: joi.array(),
-    }),
+    sass: joi.object(),
     rollup: joi.object({
-      shims: joi.object(),
       nodeResolve: joi.alternatives(joi.object(), joi.boolean()),
       commonjs: joi.alternatives(joi.object(), joi.boolean()),
-      vue: joi.alternatives(joi.object(), joi.boolean()),
-      buble: joi.alternatives(joi.object(), joi.boolean()),
       json: joi.alternatives(joi.object(), joi.boolean()),
+      vue: joi.alternatives(joi.object(), joi.boolean()),
+      shims: joi.object(),
     }),
-    sass: joi.object()
   }),
+  buble: joi.alternatives(joi.object(), joi.boolean()),
+  autoprefixer: joi.object(),
+  cssnano: joi.object(),
+  terser: joi.object(),
+  gifsicle: joi.object(),
+  jpegtran: joi.object(),
+  optipng: joi.object(),
+  svgo: joi.object(),
 });
 
 module.exports.validate = (options, cb) => {
@@ -47,38 +29,33 @@ module.exports.validate = (options, cb) => {
 
 module.exports.defaults = () => ({
   path: {},
-  buble: {},
   handlers: {
-    autoprefixer: {},
-    cssnano: {
-      safe: true,
-      autoprefixer: false,
-    },
-    terser: {},
-    gifsicle: {
-      interlaced: true,
-    },
-    jpegtran: {
-      progressive: true,
-    },
-    optipng: {
-      optimizationLevel: 5,
-    },
-    svgo: {
-      plugins: [
-        {
-          removeViewBox: true,
-        },
-      ],
-    },
+    sass: {},
     rollup: {
-      shims: {},
       nodeResolve: {}, // https://github.com/rollup/rollup-plugin-node-resolve
       commonjs: {}, // https://github.com/rollup/rollup-plugin-commonjs
-      vue: {},
-      buble: {},
       json: {}, // https://github.com/rollup/rollup-plugin-json#usage
+      vue: {}, // https://rollup-plugin-vue.vuejs.org/options.html#options
+      shims: {},
     },
-    sass: {}
+  },
+  buble: {},
+  autoprefixer: {},
+  cssnano: {
+    safe: true,
+    autoprefixer: false,
+  },
+  terser: {},
+  gifsicle: {
+    interlaced: true,
+  },
+  jpegtran: {
+    progressive: true,
+  },
+  optipng: {
+    optimizationLevel: 5,
+  },
+  svgo: {
+    plugins: [{ removeViewBox: true }],
   },
 });

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -35,6 +35,11 @@
     "stylelint-scss": "^3.3.0",
     "vue-template-compiler": "^2.5.17"
   },
+  "browserslist": [
+    "last 1 version",
+    "> 1%",
+    "not dead"
+  ],
   "yproxCli": {
     "assets": {
       "vendor": "./assets/vendor.js"

--- a/test-app/yprox-cli.config.js
+++ b/test-app/yprox-cli.config.js
@@ -28,13 +28,7 @@ module.exports = {
     objectAssign: 'Object.assign',
   },
   handlers: {
-    autoprefixer: {
-      browsers: ['> 0.25%'],
-    },
     rollup: {
-      buble: {
-        objectAssign: 'Object.assign',
-      },
       shims: {
         'app': 'App',
         'app-front': 'AppFront',


### PR DESCRIPTION
Thing like autoprefixer, cssnano, terser, gifsicle...

Not a BC because it was not documented. :thinking: 


Before:
```js
// yprox-cli.config.js
module.exports = {
  handlers: {
    buble: {},
    autoprefixer: {},
    cssnano: {},
    terser: {},
    gifsicle: {},
    jpegtran: {},
    optipng: {},
    svgo: {},
    // real handlers
    rollup: {},
    sass: {},
  }
}
```


Now:
```js
// yprox-cli.config.js
module.exports = {
  handlers: {
    // real handlers
    rollup: {},
    sass: {},
  },
  buble: {},
  autoprefixer: {},
  cssnano: {},
  terser: {},
  gifsicle: {},
  jpegtran: {},
  optipng: {},
  svgo: {},
}
```