### PR TITLE
build(deps): move Babel dependencies in dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "stylelint": ">= 9.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.2.2",
     "@kocal/semantic-release-preset": "^1.1.0",
     "@types/autoprefixer": "^9.1.1",
     "@types/cssnano": "^4.0.0",
@@ -97,6 +98,7 @@
     "@types/rollup-plugin-json": "^3.0.1",
     "@types/strip-ansi": "^3.0.0",
     "@types/stylelint": "^9.4.1",
+    "babel-core": "^7.0.0-bridge.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.11.0",
     "fs-extra": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,7 +37,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.2":
+"@babel/core@^7.1.2", "@babel/core@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687"
   integrity sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==
@@ -2226,6 +2226,11 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     private "^0.1.8"
     slash "^1.0.0"
     source-map "^0.5.7"
+
+babel-core@^7.0.0-bridge.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
 babel-extract-comments@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
They should have been removed when Webpack handler has been removed (#140)