### PR TITLE
build(deps): replace outdaded rollup-plugin-graphql by @kocal/rollup-…

### DIFF
--- a/lib/commands/build/handlers/rollup.ts
+++ b/lib/commands/build/handlers/rollup.ts
@@ -1,7 +1,7 @@
 import * as rollup from 'rollup';
 import buble from 'rollup-plugin-buble';
 import commonjs from 'rollup-plugin-commonjs';
-import graphql from 'rollup-plugin-graphql';
+import graphql from '@kocal/rollup-plugin-graphql';
 import json from 'rollup-plugin-json';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@kocal/logger": "^1.3.1",
+    "@kocal/rollup-plugin-graphql": "^1.0.0",
     "@types/autoprefixer": "^9.1.1",
     "@types/buble": "^0.19.0",
     "@types/cssnano": "^4.0.0",
@@ -71,7 +72,6 @@
     "rollup": "^1.0.0",
     "rollup-plugin-buble": "^0.19.6",
     "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-graphql": "^0.1.0",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.4.0",

--- a/types/modules.d.ts
+++ b/types/modules.d.ts
@@ -44,7 +44,7 @@ declare module 'rollup-plugin-commonjs' {
   export default fn;
 }
 
-declare module 'rollup-plugin-graphql' {
+declare module '@kocal/rollup-plugin-graphql' {
   function fn(): any;
 
   export default fn;

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,14 @@
     chalk "^2.4.1"
     luxon "^1.8.2"
 
+"@kocal/rollup-plugin-graphql@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@kocal/rollup-plugin-graphql/-/rollup-plugin-graphql-1.0.0.tgz#80132fc27abe9dd77125786e747b6e2eb8af2c6e"
+  integrity sha512-kfj4iWKGE08P7Pe3ysXV7ASH+x6HuBJoOgkxB2bXXlrNAQmMfhWhUbfVX+FeCfHw5hNz1feH1lqf6AqcQmdTxA==
+  dependencies:
+    graphql-tag "^2.2.2"
+    rollup-pluginutils "^2.0.1"
+
 "@kocal/semantic-release-preset@^1.1.0":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@kocal/semantic-release-preset/-/semantic-release-preset-1.1.7.tgz#3e5b5c37ce20dc5117bcc37ddb09a303cf13b1c4"
@@ -6442,9 +6450,9 @@ graceful-fs@^4.1.10, graceful-fs@~4.1.11:
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 graphql-tag@^2.2.2:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.0.tgz#87da024be863e357551b2b8700e496ee2d4353ae"
-  integrity sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
+  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
 
 graphql@^14.0.2:
   version "14.1.1"
@@ -12960,14 +12968,6 @@ rollup-plugin-commonjs@^9.2.0:
     magic-string "^0.25.1"
     resolve "^1.8.1"
     rollup-pluginutils "^2.3.3"
-
-rollup-plugin-graphql@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-graphql/-/rollup-plugin-graphql-0.1.0.tgz#cee3d7137133534f570826c00978eafe528069a9"
-  integrity sha512-zEAXAylBAkA489xk/KAzxtwQ5BcpcgEejsAbQ4gO19nZ8iin6+0TSogYfBhMSfZXtI4YXy3NEqwlT5E0E7rh2w==
-  dependencies:
-    graphql-tag "^2.2.2"
-    rollup-pluginutils "^2.0.1"
 
 rollup-plugin-json@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
…plugin-graphql

En écrivant un test pour GraphQL sur la PR #226, je me suis rendu compte que le plugin Rollup pour GraphQL n'était pas compatible avec Rollup 1.x, et que c'était pas du tout exploitable.

Il y a eu une PR (https://github.com/kamilkisiela/rollup-plugin-graphql/pull/7), mais le dépôt semble laissé à l'abandon. 
Donc j'ai forké le fork, j'ai fais un petit fix pour que le multi import fonctionne, et publié ça sur NPM https://www.npmjs.com/package/@kocal/rollup-plugin-graphql

Je ne modifie pas les tests ici, car ça sera fait dans #226 