### PR TITLE
chore: drop Node.js 8 support

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,8 @@
 
 ## Requirements
 
-- Node.js 8+
-- Yarn
+- Node.js 10+
+- npm or Yarn
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Hugo Alliaume <kocal@live.fr>",
   "license": "MIT",
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "files": [
     "dist",


### PR DESCRIPTION
BREAKING CHANGE: This package now requires Node.js 10